### PR TITLE
update event dev jam navlink and popup

### DIFF
--- a/data/navbar-data.ts
+++ b/data/navbar-data.ts
@@ -5,6 +5,10 @@ import { eventsData } from './content/events.content';
 // ? Edit this to change navbar items
 const currentEvent: any = eventsData.find((event) => event.current);
 
+const isEventAvailable = (event: string) => {
+  return new Date(event) >= new Date();
+};
+
 export const navItems = [
   {
     title: 'ABOUT',
@@ -55,11 +59,13 @@ export const navItems = [
     link: '/contact',
     enabled: true,
   },
+
+  // link for events
   {
     title: currentEvent.metaHead.toUpperCase(),
     common: false,
     type: 'page',
     link: `/${currentEvent.link}`,
-    enabled: true,
+    enabled: isEventAvailable(currentEvent.countdownDate),
   },
 ];


### PR DESCRIPTION
Replaced hardcoded way to enable event nav link by making calculations based on end date (This was already the case for event devjam popup - based on end date of the event)

![image](https://github.com/user-attachments/assets/fbecbea1-48a8-44e5-85b7-6f53e586367c)
